### PR TITLE
feat: add build and release workflow for znp-k1 platform

### DIFF
--- a/.github/workflows/release-znp-k1.yml
+++ b/.github/workflows/release-znp-k1.yml
@@ -48,6 +48,9 @@ jobs:
           name: ${{ github.ref_name }}-${{ steps.get-filename.outputs.filename }}
           artifacts: output/images/${{ steps.get-filename.outputs.filename }}.img.xz, output/images/${{ steps.get-filename.outputs.filename }}.img.txt
           body: |
-            This is a pre-release version of the base image, compiled by GitHub Actions.
+            This is a release version of the base image, compiled by GitHub Actions.
+            Configured to boot on v1.0 boards only.
+
+            Mind that this image is empty and should be used as a base for further customization.
 
             For more details, please see the logs [here](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}).

--- a/.github/workflows/release-znp-k1.yml
+++ b/.github/workflows/release-znp-k1.yml
@@ -1,0 +1,73 @@
+name: Armbian Compile and Release
+on:
+  push:
+    tags:
+      - "*"
+
+env:
+  RELEASE_BRANCH: "edge"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: "Build Armbian"
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run compile (should fail)
+        continue-on-error: true
+        run: |
+          ./compile.sh \
+            BOARD=znp-k1 \
+            BRANCH=${{ env.RELEASE_BRANCH }} \
+            RELEASE=bookworm \
+            BSPFREEZE=yes \
+            BUILD_MINIMAL=no \
+            BUILD_DESKTOP=no \
+            KERNEL_CONFIGURE=no \
+            EXTRAWIFI=yes \
+            INSTALL_HEADERS=yes \
+            VENDOR=OpenNept4une \
+            COMPRESS_OUTPUTIMAGE=xz
+
+      - name: Patch cache permissions
+        run: |
+          sudo chown -R root:root cache/git-bare
+
+      - name: Run compilation again
+        run: |
+          ./compile.sh \
+            BOARD=znp-k1 \
+            BRANCH=${{ env.RELEASE_BRANCH }} \
+            RELEASE=bookworm \
+            BSPFREEZE=yes \
+            BUILD_MINIMAL=no \
+            BUILD_DESKTOP=no \
+            KERNEL_CONFIGURE=no \
+            EXTRAWIFI=yes \
+            INSTALL_HEADERS=yes \
+            VENDOR=OpenNept4une \
+            COMPRESS_OUTPUTIMAGE=xz
+
+      - name: Get image filename
+        id: get-filename
+        run: echo "filename=$(basename $(ls output/images/*.img.xz) .img.xz)" >> $GITHUB_OUTPUT
+
+      - name: Release
+        uses: ncipollo/release-action@v1
+        with:
+          allowUpdates: true
+          name: ${{ github.ref_name }}-${{ steps.get-filename.outputs.filename }}
+          artifacts: output/images/${{ steps.get-filename.outputs.filename }}.img.xz, output/images/${{ steps.get-filename.outputs.filename }}.img.txt
+          body: |
+            This is a pre-release version of the base image, compiled by GitHub Actions.
+
+            For more details, please see the logs [here](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}).

--- a/.github/workflows/release-znp-k1.yml
+++ b/.github/workflows/release-znp-k1.yml
@@ -44,6 +44,7 @@ jobs:
       - name: Release
         uses: ncipollo/release-action@v1
         with:
+          prerelease: true
           allowUpdates: true
           name: ${{ github.ref_name }}-${{ steps.get-filename.outputs.filename }}
           artifacts: output/images/${{ steps.get-filename.outputs.filename }}.img.xz, output/images/${{ steps.get-filename.outputs.filename }}.img.txt

--- a/.github/workflows/release-znp-k1.yml
+++ b/.github/workflows/release-znp-k1.yml
@@ -22,27 +22,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Run compile (should fail)
-        continue-on-error: true
-        run: |
-          ./compile.sh \
-            BOARD=znp-k1 \
-            BRANCH=${{ env.RELEASE_BRANCH }} \
-            RELEASE=bookworm \
-            BSPFREEZE=yes \
-            BUILD_MINIMAL=no \
-            BUILD_DESKTOP=no \
-            KERNEL_CONFIGURE=no \
-            EXTRAWIFI=yes \
-            INSTALL_HEADERS=yes \
-            VENDOR=OpenNept4une \
-            COMPRESS_OUTPUTIMAGE=xz
-
-      - name: Patch cache permissions
-        run: |
-          sudo chown -R root:root cache/git-bare
-
-      - name: Run compilation again
+      - name: Compile
         run: |
           ./compile.sh \
             BOARD=znp-k1 \


### PR DESCRIPTION
Adding a GitHub Actions workflow to handle image construction and release generation over GitHub. This pipeline is triggered **when a tag is pushed** (ex: `git tag v0.1.6 && git push origin v0.1.6`).

~~For the build process, a [current issue](https://github.com/armbian/build/issues/6223) forces us to do some workarounds with permission. Once https://github.com/armbian/build/pull/6238 is merged, I will clean up the pipeline from the permissions' workaround.~~ Merged into mainline and merged here through this branch! 🚀 

The build process takes around 1h30m (free GitHub runners are 2-core only with minimal RAM). Still, it's free and allows us to provide a **_fully transparent_** build process for the base image.

An example of the automatically generated release [here](https://github.com/barrenechea/armbian-build-znp-k1/releases).